### PR TITLE
feat: add reconnect grace period and cleanup room on disconnect

### DIFF
--- a/RabiRiichi.Server/Connections/Connection.cs
+++ b/RabiRiichi.Server/Connections/Connection.cs
@@ -20,6 +20,11 @@ namespace RabiRiichi.Server.Connections {
     public Action<ClientMessageDto> OnReceive;
 
     /// <summary>
+    /// Callback when a streaming context is disconnected.
+    /// </summary>
+    public Action<RabiStreamingContext> OnDisconnectContext;
+
+    /// <summary>
     /// Switch to a new context. Old connection will be closed.
     /// </summary>
     protected void SwitchContext(RabiStreamingContext newCts) {
@@ -51,10 +56,9 @@ namespace RabiRiichi.Server.Connections {
     /// <param name="msg">Message to send</param>
     public void Queue(ServerMessageWrapper msg) {
       serverMsgs.TryAdd(msg.msg.Id, msg);
-      if (currentCtx == null) {
-        throw new InvalidOperationException("Websocket is not connected");
+      if (currentCtx != null) {
+        currentCtx.Queue(msg);
       }
-      currentCtx.Queue(msg);
     }
 
     /// <summary>
@@ -74,6 +78,7 @@ namespace RabiRiichi.Server.Connections {
         IServerStreamWriter<ServerMessageDto> responseStream) {
       var ctx = new RabiStreamingContext(this, requestStream, responseStream);
       ctx.OnReceive += incoming => OnReceive?.Invoke(incoming);
+      ctx.OnDisconnect += () => OnDisconnectContext?.Invoke(ctx);
 
       // Cancel previous connection and switch context
       SwitchContext(ctx);

--- a/RabiRiichi.Server/Connections/Extensions.cs
+++ b/RabiRiichi.Server/Connections/Extensions.cs
@@ -83,6 +83,17 @@ namespace RabiRiichi.Server.Connections {
           }
         });
       };
+
+      user.connection.OnDisconnectContext += rabiCtx => {
+        _ = Task.Run(async () => {
+          await Task.Delay(ServerConstants.RECONNECT_GRACE_PERIOD);
+          _ = taskQueue.Execute(() => {
+            if (user.connection.Current == rabiCtx) {
+              user.room?.RemovePlayer(user);
+            }
+          });
+        });
+      };
     }
   }
 }

--- a/RabiRiichi.Server/Models/Room.cs
+++ b/RabiRiichi.Server/Models/Room.cs
@@ -17,6 +17,7 @@ namespace RabiRiichi.Server.Models {
     private readonly User[] seats = new User[config.playerCount];
     private bool isDestroyed = false;
     private readonly Random rand = rand;
+    private CancellationTokenSource gameCts;
 
     private bool HasPlayer(User user) {
       return players.Any(p => p == user);
@@ -63,10 +64,13 @@ namespace RabiRiichi.Server.Models {
       ServerActionCenter actionCenter = new(this);
       config.actionCenter = actionCenter;
       BroadcastRoomState();
+      gameCts = new CancellationTokenSource();
       game = new Game(config);
-      Task.Run(() => game.Start()).ContinueWith(t => {
+      Task.Run(() => game.Start(gameCts.Token)).ContinueWith(t => {
         game = null;
         TryEndGame();
+        gameCts?.Dispose();
+        gameCts = null;
       });
       return true;
     }
@@ -104,7 +108,7 @@ namespace RabiRiichi.Server.Models {
         return false;
       }
       BroadcastRoomState();
-      return players.All(p => p?.status == UserStatus.Ready) ? TryStartGame() : true;
+      return !players.All(p => p?.status == UserStatus.Ready) || TryStartGame();
     }
 
     public bool CancelReady(User user) {
@@ -142,6 +146,9 @@ namespace RabiRiichi.Server.Models {
       }
       if (!players.Remove(user)) {
         return false;
+      }
+      if (game != null) {
+        gameCts?.Cancel();
       }
       BroadcastRoomState();
       if (players.Count == 0) {

--- a/RabiRiichi.Server/Models/User.cs
+++ b/RabiRiichi.Server/Models/User.cs
@@ -1,4 +1,4 @@
-﻿using RabiRiichi.Server.Connections;
+using RabiRiichi.Server.Connections;
 using RabiRiichi.Server.Generated.Messages;
 using System.ComponentModel.DataAnnotations;
 
@@ -58,7 +58,8 @@ namespace RabiRiichi.Server.Models {
     public bool ExitRoom(Room room) {
       if (this.room != room || (
           !Transit(UserStatus.InRoom, UserStatus.None)
-          && !Transit(UserStatus.Ready, UserStatus.None))) {
+          && !Transit(UserStatus.Ready, UserStatus.None)
+          && !Transit(UserStatus.Playing, UserStatus.None))) {
         return false;
       }
       this.room = null;

--- a/RabiRiichi.Server/Startup.cs
+++ b/RabiRiichi.Server/Startup.cs
@@ -4,6 +4,10 @@ using RabiRiichi.Server.Models;
 using RabiRiichi.Server.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.ConfigureKestrel(options => {
+  options.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(10);
+  options.Limits.Http2.KeepAlivePingTimeout = TimeSpan.FromMinutes(5);
+});
 var services = builder.Services;
 
 // Cors

--- a/RabiRiichi.Server/Utils/ServerUtils.cs
+++ b/RabiRiichi.Server/Utils/ServerUtils.cs
@@ -7,6 +7,7 @@ namespace RabiRiichi.Server.Utils {
     public const string MIN_CLIENT_VERSION = "0.1.0";
     public static string SERVER_VERSION => Assembly.GetExecutingAssembly().GetName().Version.ToString();
     public static readonly TimeSpan RESPONSE_TIMEOUT = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan RECONNECT_GRACE_PERIOD = TimeSpan.FromMinutes(5);
   }
 
   public static class ServerUtils {

--- a/RabiRiichi.Server/WebSockets/WebSocketController.cs
+++ b/RabiRiichi.Server/WebSockets/WebSocketController.cs
@@ -113,9 +113,7 @@ namespace RabiRiichi.Server.WebSockets {
     public async Task ConnectPublic() {
       if (HttpContext.WebSockets.IsWebSocketRequest) {
         using var webSocket =
-            await HttpContext.WebSockets.AcceptWebSocketAsync(new WebSocketAcceptContext {
-              DangerousEnableCompression = true
-            });
+            await HttpContext.WebSockets.AcceptWebSocketAsync();
         var adapter = new WebSocketAdapter(webSocket);
         var connection = new Connection();
         void PublicListener(ClientMessageDto msg) {


### PR DESCRIPTION
- Configure a 5-minute reconnect grace period.
- Prevent game loop crash by not throwing on Connection.Queue when disconnected.
- Propagate streaming context disconnection via OnDisconnectContext.
- Allow transition from Playing to None in ExitRoom.
- Manage CancellationToken in Room to cancel game when player exits.
- Configure Kestrel HTTP/2 Keep-Alive pings.
- Simplify GetReady condition in Room.cs.